### PR TITLE
Support for multiple template directories

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -15,6 +15,7 @@ class Settings extends Model
     public $sheetContentTabName = '';
     public $slugifyContentTabName = true;
     public $sidebarName = 'Spreadsheet Translations';
+    public $templateDirectories = [[ 'directoryPath' => 'templates' ]];
 
     public function rules()
     {
@@ -23,6 +24,7 @@ class Settings extends Model
             ['spreadSheetId', 'required'],
             ['sheetContentTabName', 'required'],
             ['sidebarName', 'required'],
+            ['templateDirectories', 'required'],
         ];
     }
 }

--- a/src/services/BaseSpreadsheetService.php
+++ b/src/services/BaseSpreadsheetService.php
@@ -52,14 +52,20 @@ abstract class BaseSpreadsheetService extends Component
     }
 
     /**
-     * Directory where the templates are located.
-     * @return string
+     * Directories where the templates are located.
+     * @return array
      */
-    public function templatesPath(): string
+    public function templateDirectories(): array
     {
         $basePath = \Craft::$app->config->getConfigFilePath('../yo');
         $basePath = realpath(dirname($basePath));
-        return $basePath . '/templates/';
+        $directories = [];
+
+        foreach (SpreadsheetTranslations::$plugin->getSettings()->templateDirectories as $directory) {
+          $directories[] = $basePath . '/' . $directory['directoryPath'];
+        }
+
+        return $directories;
     }
 
     /**

--- a/src/services/TemplateTranslationService.php
+++ b/src/services/TemplateTranslationService.php
@@ -38,12 +38,12 @@ class TemplateTranslationService extends BaseSpreadsheetService
 
         $result = [];
 
-        foreach ($templatesDirectories as $directoryPath) {          
+        foreach ($templatesDirectories as $directoryPath) {
           \Craft::$app->view->setTemplatesPath($directoryPath);
           $templatePaths = $this->getTemplatePaths($directoryPath);
 
           foreach ($templatePaths as $templatePath) {
-              $translations = $this->getTranslationsFromTemplateFile($directoryPath . "/" . $templatePath);
+              $translations = $this->getTranslationsFromTemplateFile($templatePath);
               $result = array_merge($result, $translations);
           }
         }
@@ -74,6 +74,7 @@ class TemplateTranslationService extends BaseSpreadsheetService
             }
             $result = array_merge($result, $extractionResult);
         }
+        
         return $result;
     }
 
@@ -103,7 +104,8 @@ class TemplateTranslationService extends BaseSpreadsheetService
      */
     private function getTranslationsFromPlainTemplateFile(string $translationPath, string $delimiterStart, string $delimiterEnd): array
     {
-        $document = file_get_contents($translationPath);
+        $templatesPath = \Craft::$app->view->getTemplatesPath();
+        $document = file_get_contents($templatesPath . '/' . $translationPath);
         return $this->extractTranslationsFromDocument($document, $delimiterStart, $delimiterEnd);
     }
 

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -63,6 +63,22 @@
     placeholder: 'Spreadsheet Translations'
 }) }}
 
+{{ forms.editableTableField({
+    label: "Template Directories",
+    instructions: 'Which directories should be scanned for translations.',
+    name: 'templateDirectories',
+    id: 'templateDirectories',
+    cols: {
+      directoryPath: {
+          type: 'singleline',
+          heading: 'Directory Path',
+          placeholder: "templates",
+      }
+    },
+    rows: settings['templateDirectories'],
+    addRowLabel: "Add a template directory",
+}) }}
+
 <div class="btn js-test-config-button">{{ 'Test credentials' | t('spreadsheet-translations') }}</div>
 <span id="graphic" class="spinner hidden js-test-config-spinner"></span>
 <p class="js-test-config-result"></p>


### PR DESCRIPTION
<img width="1155" alt="Screenshot 2022-02-22 at 14 42 55" src="https://user-images.githubusercontent.com/22011451/155155121-1490b3f3-5a69-4b13-b4dd-b13538080123.png">

Make it possible to specify multiple template directories to scan for translations. Main reason for this is that we store our Vue files under a separate directory to our twig templates. For example:

- `./templates` for twig files
- `./src/js` for any vue/js files